### PR TITLE
Some fixes from Spencer

### DIFF
--- a/Editor/CatalystAPIManager.cs
+++ b/Editor/CatalystAPIManager.cs
@@ -233,15 +233,13 @@ public class CatalystAPIManager : MonoBehaviour
 
     void Update()
     {
-        if (countdownTimer != null & countdownText != null)
+        if (countdownTimer != null && countdownText != null)
         {
-            countdownTimer = countdownTimer.Subtract(TimeSpan.FromSeconds(Time.deltaTime));
-
-            countdownText.text = FormatTime(countdownTimer);
-            
-            if (countdownTimer.TotalSeconds <= 0)
+            if (countdownTimer.TotalSeconds > 0)
             {
-                //add notification later
+                countdownTimer = countdownTimer.Subtract(TimeSpan.FromSeconds(Time.deltaTime));
+
+                countdownText.text = FormatTime(countdownTimer);
             }
         }
     }

--- a/Editor/CatalystSDK.cs
+++ b/Editor/CatalystSDK.cs
@@ -139,7 +139,11 @@ public class CatalystSDK : MonoBehaviour {
     }
 
     public string GenerateUserFingerprint() {
+#if UNITY_IOS
+        return UnityEngine.iOS.Device.vendorIdentifier;
+#else
         return SystemInfo.deviceUniqueIdentifier;
+#endif
     }
 
     private async Task SendEvent(string payload) {
@@ -302,6 +306,12 @@ public class CatalystSDK : MonoBehaviour {
             webview.OnShouldClose += (view) => {
                 HideWebview();
                 return true;
+            };
+
+            webview.OnMessageReceived += (view, message) => {
+                if (message.Path.Equals("close")) {
+                    HideWebview();
+                }
             };
 
         }


### PR DESCRIPTION
Spencer

-There's a check in the countdown clock badge that validates if TotalSeconds left in a contest is > 0 so the countdown clock can't be negative
- I added the close message to the webview. This will hide the webview rather than destroy it so it remains cached
- For iOS, I want to try using the vendorIdentifier to see if this is unique and persists through updates
